### PR TITLE
Stopping the DoScan thread and increased settings windows height

### DIFF
--- a/DayTrader/MainWindow.xaml.cs
+++ b/DayTrader/MainWindow.xaml.cs
@@ -141,6 +141,7 @@ namespace DayTrader
                             Signals.Insert(0, signal);
                         });
                     }
+	                if (!_running) break;
                 }
 				if (!_running) break;
                 SetStatusText($"sleeping.");

--- a/DayTrader/SettingsDialog.xaml
+++ b/DayTrader/SettingsDialog.xaml
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="UTF-8"?>
-<Window xmlns="https://github.com/avaloniaui" Title="Settings" Width="500" Height="300">
+<Window xmlns="https://github.com/avaloniaui" Title="Settings" Width="500" Height="350">
     <Grid ColumnDefinitions="Auto,*" RowDefinitions="Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto" Margin="10,10,10,10">
         <TextBlock Text="Exchange" Grid.Row="0" Grid.Column="0" Margin="0,0,10,10" VerticalAlignment="Center" />
         <DropDown Name="dropExchange" Grid.Row="0" Grid.Column="1"  Margin="0,0,0,10" Width="150" SelectedIndex="0" HorizontalAlignment="Left"  VerticalAlignment="Center" Items="{Binding Exchanges}" />


### PR DESCRIPTION
Basically, even when _running was set to false, the DoScan thread would not exit until it has exited the `_scanner.Symbols` foreach. Commit [25e4524](https://github.com/erwin-beckers/DayTradeScanner/commit/25e4524a4a81eaed8cffa36247a93b1cc4852a65) will break out of the foreach after waiting for a maximum of one async scan request. 
  
I've also increased the settings window's height a little bit as the `Save` and `Exit` button were not visible anymore on Windows.